### PR TITLE
replaces & with 'and' in PR title and message

### DIFF
--- a/bin/git-gh-pr
+++ b/bin/git-gh-pr
@@ -128,8 +128,8 @@ fi
 
 URL="$GH_BASE_URL/$GH_PROJECT/compare/$BASE_BRANCH_NAME...$CURRENT_BRANCH_NAME"
 URL="$URL?expand=1"
-URL="$URL&pull_request[title]=$PR_TITLE"
-URL="$URL&pull_request[body]=$PR_BODY"
+URL="$URL&pull_request[title]=${PR_TITLE//&/and}"
+URL="$URL&pull_request[body]=${PR_BODY//&/and}"
 URL="$URL&labels=status/CR-NEEDED,$ISSUE_LABELS"
 URL="$URL&milestone=$ISSUE_MILESTONE"
 URL="$URL&assignee=$GH_USERNAME"


### PR DESCRIPTION
The "&" character is not handled correctly in the title and the message data of the generated URL for opening the PR and this breaks the PR where the "&" is placed.

This PR replaces "&" with "and" to fix the issue.