### PR TITLE
use gsed instead of default sed

### DIFF
--- a/bin/git-gh-pr
+++ b/bin/git-gh-pr
@@ -27,6 +27,11 @@ urlencode() {
     LC_COLLATE=$old_lc_collate
 }
 
+SED_COMMAND=sed
+if command -v gsed 1>/dev/null ; then
+    SED_COMMAND=gsed
+fi
+
 is_git_repo
 
 # Extract some basic infos
@@ -64,9 +69,9 @@ if [ "" == "$GH_PROJECT" ]; then
 fi
 
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BASE_BRANCH_NAME=${1:-$(git show-branch 2>/dev/null | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')}
+BASE_BRANCH_NAME=${1:-$(git show-branch 2>/dev/null | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | $SED_COMMAND 's/.*\[\(.*\)\].*/\1/' | $SED_COMMAND 's/[\^~].*//')}
 
-ISSUE_ID=$(echo $CURRENT_BRANCH_NAME | sed -r 's/^[feature|fix]*\/([0-9]+|TECH)\-[a-zA-Z0-9\-]*$/\1/g' )
+ISSUE_ID=$(echo $CURRENT_BRANCH_NAME | $SED_COMMAND -r 's/^[feature|fix]*\/([0-9]+|TECH)\-[a-zA-Z0-9\-]*$/\1/g' )
 
 if [ "$ISSUE_ID" == "TECH" ]; then
     ISSUE_TITLE=""
@@ -140,7 +145,7 @@ else
   - [ ] I wrote fixtures for it <!-- remove if not needed -->
   - [ ] I wrote API doc for it  <!-- remove if not needed -->
   - [ ] I documented how to test it for QA in issue
-  - [ ] I do a commit cleanup before ask for PR (each commits reference the issue, there are no WIP commit messages, squashed similar commits, ..)
+  - [ ] I do a commit cleanup before ask for PR
 ")
 fi
 

--- a/bin/git-gh-release
+++ b/bin/git-gh-release
@@ -12,6 +12,11 @@ is_git_repo() {
 
 is_git_repo
 
+SED_COMMAND=sed
+if command -v gsed 1>/dev/null ; then
+    SED_COMMAND=gsed
+fi
+
 # Extract some basic infos
 GH_API_URL="https://api.github.com"
 GH_PROJECT=$( git config --get gh.project )
@@ -57,5 +62,5 @@ while [[ $EXTRACTED_ISSUES -ne 0 ]]; do
 
     EXTRACTED_ISSUES=$( echo $MILESTONE_ISSUES | jq 'length')
 
-    echo $MILESTONE_ISSUES | jq '.[] | select(has("pull_request") | not) | " - refs [#\(.number)](\(.html_url)): \(.title)"' | sed -e "s/^\"//g" | sed -e "s/\"$//g"
+    echo $MILESTONE_ISSUES | jq '.[] | select(has("pull_request") | not) | " - refs [#\(.number)](\(.html_url)): \(.title)"' | $SED_COMMAND -e "s/^\"//g" | $SED_COMMAND -e "s/\"$//g"
 done

--- a/bin/git-gh-start
+++ b/bin/git-gh-start
@@ -12,6 +12,11 @@ is_git_repo() {
 
 is_git_repo
 
+SED_COMMAND=sed
+if command -v gsed 1>/dev/null ; then
+    SED_COMMAND=gsed
+fi
+
 # Extract some basic infos
 GH_API_URL="https://api.github.com"
 GH_PROJECT=$( git config --get gh.project )
@@ -88,7 +93,7 @@ if [ "$ASSIGNEE_ASSIGNED" == "0" ]; then
 fi
 
 # Extract title and sluggify it
-SLUGIFIED=$(echo $ISSUE_INFO | jq -r .title | sed -e 's/[^[:alnum:]]/-/g' | sed -e 's/-\+/-/g' | sed -e 's/^-//g' | sed -e 's/-$//g' | tr A-Z a-z )
+SLUGIFIED=$(echo $ISSUE_INFO | jq -r .title | $SED_COMMAND -e 's/[^[:alnum:]]/-/g' | $SED_COMMAND -e 's/-\+/-/g' | $SED_COMMAND -e 's/^-//g' | $SED_COMMAND -e 's/-$//g' | tr A-Z a-z )
 
 Reset='\033[0m'       # Text Reset
 Underline='\033[1;4m' # Underline

--- a/git-helper-gh.rb
+++ b/git-helper-gh.rb
@@ -2,7 +2,7 @@ class GitHelperGh < Formula
   desc "Git helper for GitHub"
   homepage "https://github.com/mavimo/git-helper-gh"
   url "https://github.com/mavimo/git-helper-gh/archive/master.zip"
-  version "0.0.4"
+  version "0.0.5"
   # sha256 ""
 
   depends_on "git"


### PR DESCRIPTION
On Jan 2019 the brew do not override the system sed with gnu-sed (see stackoverflow.com/questions/30003570/how-to-use-gnu-sed-on-mac-os-x?answertab=votes#tab-top).

We use the appropriate seed if available.